### PR TITLE
[fix] /bin/bashを使わないように変更

### DIFF
--- a/linux-reset
+++ b/linux-reset
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ -L $0 ]; then
     L=$(readlink $0)

--- a/linux-reset.bat
+++ b/linux-reset.bat
@@ -1,5 +1,5 @@
 @echo off
 cd /d %~dp0
 wsl --set-default docker-desktop > nul
-wsl bash ./linux-reset %1
+wsl ./linux-reset %1
 

--- a/linux-setup
+++ b/linux-setup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ -L $0 ]; then
     L=$(readlink $0)

--- a/linux-setup.bat
+++ b/linux-setup.bat
@@ -1,4 +1,4 @@
 @echo off
 cd /d %~dp0
 wsl --set-default docker-desktop > nul
-wsl bash ./linux-setup
+wsl ./linux-setup

--- a/linux-start
+++ b/linux-start
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ -L $0 ]; then
     L=$(readlink $0)

--- a/linux-start.bat
+++ b/linux-start.bat
@@ -1,4 +1,4 @@
 @echo off
 cd /d %~dp0
 wsl --set-default docker-desktop > nul
-wsl bash ./linux-start
+wsl ./linux-start

--- a/linux-stop
+++ b/linux-stop
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ -L $0 ]; then
     L=$(readlink $0)

--- a/linux-stop.bat
+++ b/linux-stop.bat
@@ -1,4 +1,4 @@
 @echo off
 cd /d %~dp0
 wsl --set-default docker-desktop > nul
-wsl bash ./linux-stop
+wsl ./linux-stop


### PR DESCRIPTION
Docker Desktop(Win) 4.18に上げたらbashが見つからなくなってるみたいで難儀なことに。
結局/bin/shを使う方式に修正して動くように戻りました。